### PR TITLE
[Feature] 신고 기능 백엔드, 프론트 일부 구현.

### DIFF
--- a/backend/src/main/java/com/example/backend/exception/HaehaeExceptionHandler.java
+++ b/backend/src/main/java/com/example/backend/exception/HaehaeExceptionHandler.java
@@ -44,6 +44,15 @@ public class HaehaeExceptionHandler {
 
         return ResponseEntity.status(status).body(body);
     }
+
+    @ExceptionHandler(PenaltyException.class)
+    public ResponseEntity<Map<String, Object>> handleCustomException(PenaltyException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("message", ex.getMessage());
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+
+        return ResponseEntity.status(status).body(body);
+    }
 }
 
 

--- a/backend/src/main/java/com/example/backend/exception/PenaltyException.java
+++ b/backend/src/main/java/com/example/backend/exception/PenaltyException.java
@@ -1,0 +1,14 @@
+package com.example.backend.exception;
+
+public class PenaltyException extends RuntimeException {
+   private final String message;
+    public PenaltyException(String message) {
+        super(message);
+        this.message = message;
+    }
+
+    @Override
+    public String getMessage() {
+      return message;
+    }
+}

--- a/backend/src/main/java/com/example/backend/localBoard/board/service/DetailCommandServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/localBoard/board/service/DetailCommandServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.backend.localBoard.board.service;
 
+import com.example.backend.exception.PenaltyException;
 import com.example.backend.localBoard.board.dto.request.CreateContentRequestDTO;
 import com.example.backend.localBoard.board.dto.request.ImageRequestDTO;
 import com.example.backend.localBoard.board.dto.request.UpdateContentRequestDTO;
@@ -7,6 +8,7 @@ import com.example.backend.entity.localBoard.LocalBoardImages;
 import com.example.backend.entity.localBoard.LocalBoards;
 import com.example.backend.localBoard.board.repository.LocalBoardRepository;
 import com.example.backend.localBoard.image.repository.BoardImageRepository;
+import com.example.backend.userPenalty.service.UserPenaltyService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,15 +20,27 @@ import java.time.LocalDateTime;
 @Service
 public class DetailCommandServiceImpl implements DetailCommandService {
 
+    private final UserPenaltyService userPenaltyService;
+
     @Autowired
     LocalBoardRepository localBoardRepository;
 
     @Autowired
     BoardImageRepository boardImageRepository;
 
+    public DetailCommandServiceImpl(UserPenaltyService userPenaltyService) {
+        this.userPenaltyService = userPenaltyService;
+    }
+
     @Override
     @Transactional
     public void createDetail(CreateContentRequestDTO createContentRequestDTO){
+      // 유저의 패널티 적용 기간.
+      String penaltyTime =  userPenaltyService.existEndAtUserId(createContentRequestDTO.getUserId());
+      if(penaltyTime != null){
+        throw new PenaltyException("정지 남은 시간 : " +penaltyTime);
+      }
+
 
         LocalBoards localBoards
                 = LocalBoards.builder()
@@ -54,6 +68,12 @@ public class DetailCommandServiceImpl implements DetailCommandService {
 
     @Override
     public void updateDetail(long localBoardId, UpdateContentRequestDTO updateContentRequestDTO){
+        // 유저의 패널티 적용 기간.
+        String penaltyTime =  userPenaltyService.existEndAtUserId(updateContentRequestDTO.getUserId());
+        if(penaltyTime != null){
+            throw new PenaltyException("정지 남은 시간 : " +penaltyTime);
+        }
+
         updateContentRequestDTO.setUpdateAt(Timestamp.valueOf(LocalDateTime.now()));
         localBoardRepository.updateDetailContent(localBoardId, updateContentRequestDTO);
     }

--- a/backend/src/main/java/com/example/backend/localBoard/comment/service/CommentCommandServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/localBoard/comment/service/CommentCommandServiceImpl.java
@@ -1,21 +1,35 @@
 package com.example.backend.localBoard.comment.service;
 
 import com.example.backend.entity.localBoard.Comments;
+import com.example.backend.exception.PenaltyException;
 import com.example.backend.localBoard.comment.dto.request.CommentRequestDTO;
 import com.example.backend.localBoard.comment.dto.request.ReplyRequestDTO;
 import com.example.backend.localBoard.comment.dto.request.UpdateCommentRequestDTO;
 import com.example.backend.localBoard.comment.repository.BoardCommentRepository;
+import com.example.backend.userPenalty.service.UserPenaltyService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class CommentCommandServiceImpl implements CommentCommandService {
 
+    private final UserPenaltyService userPenaltyService;
+
     @Autowired
     BoardCommentRepository boardCommentRepository;
 
+    public CommentCommandServiceImpl(UserPenaltyService userPenaltyService) {
+        this.userPenaltyService = userPenaltyService;
+    }
+
     @Override
     public void createComment(CommentRequestDTO commentRequestDTO) {
+
+        // 유저의 패널티 적용 기간.
+        String penaltyTime =  userPenaltyService.existEndAtUserId(commentRequestDTO.getUserId());
+        if(penaltyTime != null){
+            throw new PenaltyException("정지 남은 시간 : " +penaltyTime);
+        }
 
         Comments comments = Comments.builder()
                 .localBoardId(commentRequestDTO.getLocalBoardId())
@@ -29,6 +43,12 @@ public class CommentCommandServiceImpl implements CommentCommandService {
 
     @Override
     public void modifyComment(UpdateCommentRequestDTO updateCommentRequestDTO) {
+//        // 유저의 패널티 적용 기간.
+//        String penaltyTime =  userPenaltyService.existEndAtUserId(updateCommentRequestDTO);
+//        if(penaltyTime != null){
+//            throw new PenaltyException("정지 남은 시간 : " +penaltyTime);
+//        }
+
         boardCommentRepository.modifyComment(updateCommentRequestDTO);
     };
 
@@ -40,6 +60,12 @@ public class CommentCommandServiceImpl implements CommentCommandService {
     @Override
     public void createChildComment(ReplyRequestDTO replyRequestDTO) {
         System.out.println("🔥 createChildComment() 들어옴!!");
+
+        // 유저의 패널티 적용 기간.
+        String penaltyTime =  userPenaltyService.existEndAtUserId(replyRequestDTO.getUserId());
+        if(penaltyTime != null){
+            throw new PenaltyException("정지 남은 시간 : " +penaltyTime);
+        }
 
         System.out.println("🔥 DTO 값 확인:");
         System.out.println("localBoardId: " + replyRequestDTO.getLocalBoardId());

--- a/backend/src/main/java/com/example/backend/mission/missions/service/MissionServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/mission/missions/service/MissionServiceImpl.java
@@ -8,6 +8,7 @@ import com.example.backend.mission.missions.repsository.MissionsRepository;
 import com.example.backend.mission.previewMissions.repository.PreviewMissionRepository;
 import com.example.backend.pagination.response.CursorPageResponse;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -53,6 +54,7 @@ public class MissionServiceImpl implements  MissionService {
 
     // 미션 등록
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     public void missionInsert(MissionInsertRequestDTO dto) {
         if(missionsRepository.existsByMissionContent(dto.getMissionContent())){
             throw new IllegalArgumentException("해당 제목의 미션이 존재합니다.");
@@ -62,6 +64,7 @@ public class MissionServiceImpl implements  MissionService {
 
     // 미션 수정
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     public void missionUpdate(MissionUpdateRequestDTO dto) {
         if(missionsRepository.existsByMissionContentAndIdNot(dto.getMissionContent(), dto.getId())){
             throw new IllegalArgumentException("해당 제목의 미션이 존재합니다.");
@@ -71,6 +74,7 @@ public class MissionServiceImpl implements  MissionService {
 
     // 미션 삭제
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     public void missionDelete(Long id) {
         if(!missionsRepository.existsById(id)){
             throw new IllegalArgumentException("해당 미션이 존재 하지 않습니다.");
@@ -80,13 +84,11 @@ public class MissionServiceImpl implements  MissionService {
 
     // 미션 리스트 삭제
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     public void missionDeleteList(List<Long> idList) {
         if(idList == null || idList.isEmpty()){
             throw new IllegalArgumentException("삭제 할 미션을 선택하지 않았습니다.");
         }
         missionsRepository.deleteAllById(idList);
     }
-
-
-
 }

--- a/backend/src/main/java/com/example/backend/mission/previewMissions/service/PreviewMissionServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/mission/previewMissions/service/PreviewMissionServiceImpl.java
@@ -32,7 +32,7 @@ public class PreviewMissionServiceImpl implements  PreviewMissionService {
     }
 
     @Transactional
-    @Scheduled(cron = "0 14 15 * * SUN") // 매주 월요일 오전 9시 0 0 9 * * MON
+    @Scheduled(cron = "0 0 9 * * MON") // 매주 월요일 오전 9시 0 0 9 * * MON
     public void scheduledWeeklyMission(){
         if(previewMissionRepository.existByActiveMission(PreviewMissions.PreviewMissionStatus.ACTIVE, PreviewMissions.PreviewMissionType.WEEKLY)) {
             missionWeeklyActiveUpdate();
@@ -48,7 +48,7 @@ public class PreviewMissionServiceImpl implements  PreviewMissionService {
     }
 
     @Transactional
-    @Scheduled(cron = "0 47 14 * * *") // 매일 9시  0 0 9 * * *
+    @Scheduled(cron = "0 0 9 * * *") // 매일 9시  0 0 9 * * *
     public void scheduledDailyMission(){
         if(previewMissionRepository.existByActiveMission(PreviewMissions.PreviewMissionStatus.ACTIVE, PreviewMissions.PreviewMissionType.DAILY)) {
             missionDailyActiveUpdate();

--- a/backend/src/main/java/com/example/backend/mission/previewMissions/service/PreviewMissionServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/mission/previewMissions/service/PreviewMissionServiceImpl.java
@@ -15,6 +15,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.transaction.Transactional;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.sql.Timestamp;
@@ -252,12 +253,14 @@ public class PreviewMissionServiceImpl implements  PreviewMissionService {
 
     // 관리자가 직접 PreviewMissions 삽입,
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     public void previewMissionInsert(PreviewMissionRequestDTO dto) {
         previewMissionRepository.save(dto.toPreviewMissionEntity());
     }
 
     // 관리자가 직접 수정
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     public void previewMissionUpdate(PreviewMissionUpdateRequestDTO dto) {
         previewMissionRepository.save(dto.toPreviewMissionEntity());
     }
@@ -265,6 +268,7 @@ public class PreviewMissionServiceImpl implements  PreviewMissionService {
     // 관리자가 직접 삭제
     // 삭제시 프론트단에서 경고 모달 구현해야함!!
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     public void previewDeleteById(Long id) {
         previewMissionRepository.deleteById(id);
     }
@@ -272,10 +276,12 @@ public class PreviewMissionServiceImpl implements  PreviewMissionService {
     // 관리자가 직접 삭제
     // 삭제시 프론트단에서 경고 모달 구현해야함!!
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     public void previewDeleteByType(PreviewMissions.PreviewMissionType previewMissionType, PreviewMissions.PreviewMissionStatus previewMissionStatus) {
         previewMissionRepository.deleteByAllType(previewMissionType,previewMissionStatus);
     }
 
+    // 미션과 유저의 미션상태를 함께 전달.
     @Override
     public List<PreviewMissionListAndUserStatusDTO> userPreviewMissionAndStatus(Long userId) {
        List<PreviewMissionListAndUserStatusDTO> list =  previewMissionRepository.userPreviewMissionAndStatus(PreviewMissions.PreviewMissionStatus.ACTIVE,userId);

--- a/backend/src/main/java/com/example/backend/mission/userMissionStatus/controller/UserMissionStatusController.java
+++ b/backend/src/main/java/com/example/backend/mission/userMissionStatus/controller/UserMissionStatusController.java
@@ -22,9 +22,9 @@ public class UserMissionStatusController {
         return new ResponseEntity<>("상태 확인 및 업데이트" , HttpStatus.OK);
     }
 
-    @PostMapping("update")
-    public ResponseEntity<String> updateStatus(@RequestBody UserMissionSuccessRequestDTO dto){
-        userMissionStatusService.completeUpdateUserStatus(dto);
+    @PostMapping("update/{userId}")
+    public ResponseEntity<String> updateStatus(@PathVariable Long userId,  @RequestBody UserMissionSuccessRequestDTO dto){
+        userMissionStatusService.completeUpdateUserStatus(userId, dto);
         return new ResponseEntity<>("업데이트 성공", HttpStatus.OK);
     }
 

--- a/backend/src/main/java/com/example/backend/mission/userMissionStatus/service/UserMissionStatusService.java
+++ b/backend/src/main/java/com/example/backend/mission/userMissionStatus/service/UserMissionStatusService.java
@@ -5,5 +5,5 @@ import com.example.backend.userPoint.dto.request.UserMissionSuccessRequestDTO;
 
 public interface UserMissionStatusService {
     void checkStatusUpdate(Long userId);
-    void completeUpdateUserStatus(UserMissionSuccessRequestDTO dto);
+    void completeUpdateUserStatus(Long userId, UserMissionSuccessRequestDTO dto);
 }

--- a/backend/src/main/java/com/example/backend/mission/userMissionStatus/service/UserMissionStatusServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/mission/userMissionStatus/service/UserMissionStatusServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.backend.mission.userMissionStatus.service;
 
 import com.example.backend.entity.mission.PreviewMissions;
 import com.example.backend.entity.mission.UserMissionStatus;
+import com.example.backend.entity.mission.UserMissions;
 import com.example.backend.entity.reward.RewardItems;
 import com.example.backend.entity.user.UserLevel;
 import com.example.backend.entity.user.UserPoint;
@@ -22,6 +23,7 @@ import com.example.backend.userLevel.repsoitory.UserLevelRepository;
 import com.example.backend.userPoint.dto.request.UserMissionSuccessRequestDTO;
 import com.example.backend.userPoint.repository.UserPointRepository;
 import jakarta.transaction.Transactional;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.sql.Timestamp;
@@ -57,6 +59,7 @@ public class UserMissionStatusServiceImpl implements UserMissionStatusService{
     // 3. 사용자의 유저 미션 상태 조회
     // 4. 사용자 미션에 맞추어서 유저 미션 상태 업데이트
     @Override
+    @PreAuthorize("isAuthenticated()")
     public void checkStatusUpdate(Long userId){
         List<PreviewMissionListResponseDTO> missinList =  previewMissionService.findPreviewALlActive();
 
@@ -147,7 +150,8 @@ public class UserMissionStatusServiceImpl implements UserMissionStatusService{
     // 4. 현재 포인트 반영, 총포인트 반영
     @Transactional
     @Override
-    public void completeUpdateUserStatus(UserMissionSuccessRequestDTO dto) {
+    @PreAuthorize("isAuthenticated() and @userMissionStatusServiceImpl.isOwnerOfUserMissionStatus(#dto.userMissionId, principal.id)")
+    public void completeUpdateUserStatus(Long userId, UserMissionSuccessRequestDTO dto) {
 
         if(dto == null){
             throw new IllegalArgumentException("dto의 값이 없음.");
@@ -217,5 +221,12 @@ public class UserMissionStatusServiceImpl implements UserMissionStatusService{
             userMissionStatusRepository.save(dto.toUserMissionStatusUpdateEntity());
         }
 
+    }
+
+    private boolean isOwnerOfUserMissionStatus(Long userMissionStatusId, Long principalId){
+        return userMissionStatusRepository.findById(userMissionStatusId)
+                .map(UserMissionStatus::getUserId)
+                .map(statusUserId -> statusUserId.equals(principalId))
+                .orElse(false);
     }
 }

--- a/backend/src/main/java/com/example/backend/mission/userMissionStatus/service/UserMissionStatusServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/mission/userMissionStatus/service/UserMissionStatusServiceImpl.java
@@ -184,6 +184,7 @@ public class UserMissionStatusServiceImpl implements UserMissionStatusService{
             userRepository.updateCurrentPoint(plusPoint, dto.getUserId());
             userRepository.updateTotalPoint(totalPlusPoint, dto.getUserId());
 
+
 //            //5. 필요시 유저 등급 업데이트
 //            long userLevelId = currentAndTotalPoint.getUserLevelId();
 //            if(userLevelId < 4) {

--- a/backend/src/main/java/com/example/backend/report/service/ReportServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/report/service/ReportServiceImpl.java
@@ -8,6 +8,7 @@ import com.example.backend.report.dto.response.UpdateReportInfoDTO;
 import com.example.backend.report.dto.response.UpdateReportListDTO;
 import com.example.backend.report.repository.ReportRepository;
 import jakarta.transaction.Transactional;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -49,16 +50,17 @@ public class ReportServiceImpl implements ReportService{
     }
 
     @Override
+    @PreAuthorize("isAuthenticated()")
     public void registerReport(ReportInsertRequestDTO reportInsertRequestDTO) {
         reportRepository.save(reportInsertRequestDTO.toEntity());
     }
-
 
     // 1. id로 조회
     // 2. 타겟대상과, 타켓 타입을 가져온다. 
     // 3. 해당 다켓대상과 타켓타입을 가진 리스트 모두 업데이트
     @Transactional
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     public UpdateReportInfoDTO updateReport(Long id, Report.Status status) {
         UpdateReportInfoDTO updateReportInfo = reportRepository.findReportTargetTypeAndTargetId(id);
         Long targetId = updateReportInfo.getTargetId();

--- a/backend/src/main/java/com/example/backend/reward/rewardItems/service/RewardItemsServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/reward/rewardItems/service/RewardItemsServiceImpl.java
@@ -11,11 +11,9 @@ import com.example.backend.entity.reward.RewardItemImages;
 import com.example.backend.entity.reward.RewardItems;
 import com.example.backend.reward.rewardItmeImages.repository.RewardImageRepository;
 import com.example.backend.reward.rewardItems.repository.RewardRepository;
-import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 
@@ -32,6 +30,7 @@ public class RewardItemsServiceImpl implements RewardItemsService {
 
     @Transactional
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     public void rewardItemInsert(RewardRequestDTO dto) {
         if(dto.getRewardType() != RewardItems.RewardType.DONATION){
             if(dto.getStock()<=0){
@@ -87,6 +86,7 @@ public class RewardItemsServiceImpl implements RewardItemsService {
     }
 
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     public void rewardItemUpdate(RewardItemsRequestUpdateDTO dto) {
 
         if(dto.getRewardType() != RewardItems.RewardType.DONATION) {
@@ -102,6 +102,7 @@ public class RewardItemsServiceImpl implements RewardItemsService {
 
     @Transactional
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     public void rewardDeleteById(long id) {
         if(!rewardRepository.existsById(id)){
             throw new RewardException("해당 게시물의 정보가 없습니다.");

--- a/backend/src/main/java/com/example/backend/reward/rewardItmeImages/service/RewardItemImagesServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/reward/rewardItmeImages/service/RewardItemImagesServiceImpl.java
@@ -4,6 +4,7 @@ import com.example.backend.reward.rewardItmeImages.dto.request.RewardImagesUpdat
 import com.example.backend.reward.rewardItmeImages.repository.RewardImageRepository;
 import com.example.backend.reward.rewardItems.repository.RewardRepository;
 import jakarta.transaction.Transactional;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.lang.reflect.Array;
@@ -21,6 +22,7 @@ public class RewardItemImagesServiceImpl implements RewardItemImagesService {
     }
     @Transactional
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     public void rewardItemImagesUpdate(List<RewardImagesUpdateDTO> dtoList) {
         for(RewardImagesUpdateDTO dto : dtoList) {
             if (!rewardRepository.existsById(dto.getRewardItemId())) {
@@ -37,6 +39,7 @@ public class RewardItemImagesServiceImpl implements RewardItemImagesService {
     }
     @Transactional
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     public void rewardItemImagesDelete(String  ids) {
         List<Long> idList = Arrays.stream(ids.split(","))
                 .map(Long::parseLong)
@@ -55,6 +58,7 @@ public class RewardItemImagesServiceImpl implements RewardItemImagesService {
     }
     @Transactional
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     public void rewardItemIamgeDeleteAll(long id) {
         if(!rewardRepository.existsById(id)){
             throw new IllegalArgumentException("해당 게시물이 존재하지 않습니다.");

--- a/backend/src/main/java/com/example/backend/reward/userReward/service/UserRewardServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/reward/userReward/service/UserRewardServiceImpl.java
@@ -13,6 +13,7 @@ import com.example.backend.user.repository.UserRepository;
 import com.example.backend.userPoint.repository.UserPointRepository;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -30,8 +31,17 @@ public class UserRewardServiceImpl implements UserRewardService {
         this.rewardRepository = rewardRepository;
     }
 
+
+    // 리워드 결제 등록
+    // 1. 권한 체크
+    // 2. 포인트 예외처리
+    // 3. 유저 포인트 등록
+    // 4. 유저 리워드 등록
+    // 5. 재고 예외처리
+    // 6. 유저 현재 포인트 업데이트
     @Transactional
     @Override
+    @PreAuthorize("isAuthenticated()")
     public Long userRewardPointInsert(UserRewardPointRequestInsertDTO dto) {
         long amount = dto.getAmount();
         long id = dto.getUserId();
@@ -77,8 +87,15 @@ public class UserRewardServiceImpl implements UserRewardService {
         return currentPoint;
     }
 
+    // 환불 로직
+    // 권한 체크와 , 해당 유저가 결제한 정보가 맞는지 확인.
+    // 유저 포인트 환불 업데이트
+    // 유저 리워드 환불 업데이트
+    // 재고 업데이트
+    // 유저의 현재 포인트와 총 포인트 업데이트
     @Override
     @Transactional
+    @PreAuthorize("hasRole('ADMIN') or (isAuthenticated() and @userRewardService.isOwnerOfUserPoint(#userPointId, principal.id))")
     public void userRewardPayRefund(Long userPointId) {
         UserPoint point =  userPointRepository.findById(userPointId)
         .orElseThrow(() -> new RewardException("결제 정보가 존재하지 않습니다."));
@@ -124,5 +141,12 @@ public class UserRewardServiceImpl implements UserRewardService {
         long resultPoint =  currentPoint + point.getAmount();
         userRepository.updateCurrentPoint(resultPoint, point.getUserId());
 
+    }
+
+    // 해당 유저가 결제한 정보가 맞는지 체크하는 로직.
+    private Boolean isOwnerOfUserPoint(Long userPointId, Long userId){
+        return userPointRepository.findById(userPointId)
+                .map(userPoint -> userPoint.getUserId().equals(userId))
+                .orElse(false);
     }
 }

--- a/backend/src/main/java/com/example/backend/sharing/service/SharingCommandServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/sharing/service/SharingCommandServiceImpl.java
@@ -4,6 +4,7 @@ import com.example.backend.entity.sharing.SharingImages;
 import com.example.backend.entity.sharing.SharingPosts;
 import com.example.backend.exception.ErrorCode;
 import com.example.backend.exception.HaehaeException;
+import com.example.backend.exception.PenaltyException;
 import com.example.backend.sharing.dto.request.CreateSharingRequestDTO;
 import com.example.backend.sharing.dto.request.SharingImageRequestDTO;
 import com.example.backend.sharing.dto.request.SharingStatusRequestDTO;
@@ -11,12 +12,15 @@ import com.example.backend.sharing.dto.request.UpdateSharingRequestDTO;
 import com.example.backend.sharing.repository.sharingPosts.SharingRepository;
 import com.example.backend.sharing.repository.images.SharingImageRepository;
 import com.example.backend.user.repository.UserRepository;
+import com.example.backend.userPenalty.service.UserPenaltyService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class SharingCommandServiceImpl implements SharingCommandService {
+
+    private final UserPenaltyService userPenaltyService;
 
     @Autowired
     private SharingRepository sharingRepository;
@@ -27,9 +31,19 @@ public class SharingCommandServiceImpl implements SharingCommandService {
     @Autowired
     private UserRepository userRepository;
 
+    public SharingCommandServiceImpl(UserPenaltyService userPenaltyService) {
+        this.userPenaltyService = userPenaltyService;
+    }
+
     @Transactional
     @Override
     public void createSharingDetail(CreateSharingRequestDTO createSharingRequestDTO) {
+
+        // 유저의 패널티 적용 기간.
+        String penaltyTime =  userPenaltyService.existEndAtUserId(createSharingRequestDTO.getUserId());
+        if(penaltyTime != null){
+            throw new PenaltyException("정지 남은 시간 : " +penaltyTime);
+        }
 
         if (!userRepository.existsById(createSharingRequestDTO.getUserId())) {
             throw new HaehaeException(ErrorCode.USER_NOT_FOUND);
@@ -65,6 +79,13 @@ public class SharingCommandServiceImpl implements SharingCommandService {
 
     @Override
     public void updateSharingDetail(UpdateSharingRequestDTO updateSharingRequestDTO) {
+
+        // 유저의 패널티 적용 기간.
+        String penaltyTime =  userPenaltyService.existEndAtUserId(updateSharingRequestDTO.getUserId());
+        if(penaltyTime != null){
+            throw new PenaltyException("정지 남은 시간 : " +penaltyTime);
+        }
+
         sharingRepository.updateSharingDetail(updateSharingRequestDTO);
     }
 

--- a/backend/src/main/java/com/example/backend/user/repository/UserRepositoryCustom.java
+++ b/backend/src/main/java/com/example/backend/user/repository/UserRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.example.backend.user.repository;
 
 
+import com.example.backend.entity.user.User;
 import com.example.backend.user.dto.TotalAndLevelDTO;
 
 import com.example.backend.user.dto.MyPageInfo;
@@ -15,4 +16,6 @@ public interface UserRepositoryCustom {
     Long updateProfile(Long userId, String nickname, String profileImageUrl);
 
     MyPageInfo getMypageInfo(Long userId);
+
+    void permanentStop(Long userId, User.Status status);
 }

--- a/backend/src/main/java/com/example/backend/user/repository/UserRepositoryImpl.java
+++ b/backend/src/main/java/com/example/backend/user/repository/UserRepositoryImpl.java
@@ -113,4 +113,15 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
                 .where(u.id.eq(userId))
                 .fetchOne();
     }
+
+    // 영구정지
+    @Override
+    public void permanentStop(Long userId, User.Status status) {
+        QUser u = QUser.user;
+         queryFactory
+                .update(u)
+                .set(u.status, status)
+                .where(u.id.eq(userId))
+                .execute();
+    }
 }

--- a/backend/src/main/java/com/example/backend/userPenalty/repository/UserPenaltyRepository.java
+++ b/backend/src/main/java/com/example/backend/userPenalty/repository/UserPenaltyRepository.java
@@ -16,4 +16,5 @@ public interface UserPenaltyRepository extends JpaRepository<UserPenalty,Long> {
             " AND up.penaltyStatus = :penaltyStatus" +
             " ORDER BY up.endAt DESC")
     Timestamp existEndAtUserId(@Param("penaltyUserId") Long penaltyUserId,@Param("penaltyStatus") UserPenalty.PenaltyStatus penaltyStatus);
+
 }

--- a/backend/src/main/java/com/example/backend/userPenalty/service/UserPenaltyService.java
+++ b/backend/src/main/java/com/example/backend/userPenalty/service/UserPenaltyService.java
@@ -1,7 +1,11 @@
 package com.example.backend.userPenalty.service;
 
+import com.example.backend.entity.report.UserPenalty;
 import com.example.backend.userPenalty.dto.FrontUserPenaltyRequestDTO;
+
+import java.sql.Timestamp;
 
 public interface UserPenaltyService {
     void userPenaltySave(FrontUserPenaltyRequestDTO dto);
+    String existEndAtUserId(Long userId);
 }

--- a/backend/src/main/java/com/example/backend/userPenalty/service/UserPenaltyServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/userPenalty/service/UserPenaltyServiceImpl.java
@@ -6,12 +6,14 @@ import com.example.backend.entity.localBoard.LocalBoards;
 import com.example.backend.entity.report.Report;
 import com.example.backend.entity.report.UserPenalty;
 import com.example.backend.entity.sharing.SharingPosts;
+import com.example.backend.entity.user.User;
 import com.example.backend.localBoard.board.repository.LocalBoardRepository;
 import com.example.backend.localBoard.comment.repository.BoardCommentRepository;
 import com.example.backend.report.dto.response.UpdateReportInfoDTO;
 import com.example.backend.report.service.ReportService;
 import com.example.backend.sharing.dto.request.SharingStatusRequestDTO;
 import com.example.backend.sharing.repository.sharingPosts.SharingRepository;
+import com.example.backend.user.repository.UserRepository;
 import com.example.backend.userPenalty.dto.FrontUserPenaltyRequestDTO;
 import com.example.backend.userPenalty.dto.UserPenaltyInsertRequestDTO;
 import com.example.backend.userPenalty.repository.UserPenaltyRepository;
@@ -19,6 +21,7 @@ import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
 import java.sql.Timestamp;
+import java.time.Duration;
 import java.time.LocalDateTime;
 
 @Service
@@ -30,14 +33,16 @@ public class UserPenaltyServiceImpl implements UserPenaltyService{
     private final BoardCommentRepository boardCommentRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final SharingRepository sharingRepository;
+    private final UserRepository userRepository;
 
-    public UserPenaltyServiceImpl(UserPenaltyRepository userPenaltyRepository, ReportService reportService, LocalBoardRepository localBoardRepository, BoardCommentRepository boardCommentRepository, ChatMessageRepository chatMessageRepository, SharingRepository sharingRepository) {
+    public UserPenaltyServiceImpl(UserPenaltyRepository userPenaltyRepository, ReportService reportService, LocalBoardRepository localBoardRepository, BoardCommentRepository boardCommentRepository, ChatMessageRepository chatMessageRepository, SharingRepository sharingRepository, UserRepository userRepository) {
         this.userPenaltyRepository = userPenaltyRepository;
         this.reportService = reportService;
         this.localBoardRepository = localBoardRepository;
         this.boardCommentRepository = boardCommentRepository;
         this.chatMessageRepository = chatMessageRepository;
         this.sharingRepository = sharingRepository;
+        this.userRepository = userRepository;
     }
 
 
@@ -124,15 +129,8 @@ public class UserPenaltyServiceImpl implements UserPenaltyService{
                         reportId
                 );
             } else {
-                // 1000년 정지.
-                Timestamp permanentStop = Timestamp.valueOf(LocalDateTime.now().plusYears(1000));
-                userPenaltyInsertRequestDTO = new UserPenaltyInsertRequestDTO(
-                        userId,
-                        reasonCode,
-                        now,
-                        permanentStop,
-                        reportId
-                );
+                // 영구정지
+                userRepository.permanentStop(userId, User.Status.BLOCKED);
             }
        }else {
           LocalDateTime endAt = userEndAt.toLocalDateTime();
@@ -155,16 +153,38 @@ public class UserPenaltyServiceImpl implements UserPenaltyService{
                        reportId
                );
            } else {
-               Timestamp permanentStop = Timestamp.valueOf(endAt.plusYears(1000));
-               userPenaltyInsertRequestDTO = new UserPenaltyInsertRequestDTO(
-                       userId,
-                       reasonCode,
-                       userEndAt,
-                       permanentStop,
-                       reportId
-               );
+               // 영구정지.
+                userRepository.permanentStop(userId, User.Status.BLOCKED);
            }
        }
        userPenaltyRepository.save(userPenaltyInsertRequestDTO.toUserPenaltyEntity());
+    }
+    
+    // 유저 패널티 적용 기간 체크 메서드
+    // 1. 지역 게시판  작성 , 수정
+    // 2. 댓글 작성, 대댓글 작성,  수정(보류)
+    // 3. 나눔 게시판 작성, 수정
+    @Override
+    public String existEndAtUserId(Long userId) {
+        Timestamp now = Timestamp.valueOf(LocalDateTime.now());
+        Timestamp endAt =  userPenaltyRepository.existEndAtUserId(userId, UserPenalty.PenaltyStatus.ACTIVE);
+        String remainTime = null;
+
+        if(endAt == null){
+            throw new IllegalArgumentException("제제 정보가 없습니다.");
+        }
+
+        if(endAt.after(now)){
+            Duration duration = Duration.between(now.toLocalDateTime(), endAt.toLocalDateTime());
+
+            long day = duration.toDaysPart();
+            long hours = duration.toHoursPart();
+            long minutes = duration.toMinutesPart();
+
+            remainTime = day + "일 "+hours+"시 "+minutes+"분";
+        }
+
+
+        return remainTime;
     }
 }

--- a/backend/src/main/java/com/example/backend/userPenalty/service/UserPenaltyServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/userPenalty/service/UserPenaltyServiceImpl.java
@@ -18,6 +18,7 @@ import com.example.backend.userPenalty.dto.FrontUserPenaltyRequestDTO;
 import com.example.backend.userPenalty.dto.UserPenaltyInsertRequestDTO;
 import com.example.backend.userPenalty.repository.UserPenaltyRepository;
 import jakarta.transaction.Transactional;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.sql.Timestamp;
@@ -54,6 +55,7 @@ public class UserPenaltyServiceImpl implements UserPenaltyService{
     // 5. 유저 정지.
     @Transactional
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     public void userPenaltySave(FrontUserPenaltyRequestDTO dto) {
         Long reportId = dto.getReportId();
         Long period = dto.getPeriod();
@@ -181,7 +183,7 @@ public class UserPenaltyServiceImpl implements UserPenaltyService{
             long hours = duration.toHoursPart();
             long minutes = duration.toMinutesPart();
 
-            remainTime = day + "일 "+hours+"시 "+minutes+"분";
+            remainTime = day + "일 "+hours+"시간 "+minutes+"분";
         }
 
 

--- a/backend/src/main/java/com/example/backend/userPoint/service/UserPointServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/userPoint/service/UserPointServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.backend.userPoint.service;
 
 import com.example.backend.entity.user.User;
+import com.example.backend.entity.user.UserPoint;
 import com.example.backend.exception.RewardException;
 import com.example.backend.userPoint.dto.response.PaymentResponseDTO;
 import com.example.backend.userPoint.repository.UserPointRepository;
@@ -17,11 +18,18 @@ public class UserPointServiceImpl implements UserPointService{
     }
 
     @Override
+    @PreAuthorize("isAuthenticated() and @userRewardService.isOwnerOfUserPoint(#userPointId, principal.id)")
     public PaymentResponseDTO payResult(Long userPointId) {
         PaymentResponseDTO dto = userPointRepository.payResponse(userPointId);
         if (dto == null) {
             throw new RewardException("해당 userPointId에 대한 결제 정보를 찾을 수 없습니다.");
         }
         return dto;
+    }
+
+    private boolean isOwnerOfPointById(Long userPointId,Long userId){
+        return userPointRepository.findById(userPointId)
+                .map(userPoint -> userPoint.getUserId().equals(userId))
+                .orElse(false);
     }
 }

--- a/backend/src/main/java/com/example/backend/userPoint/service/UserPointServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/userPoint/service/UserPointServiceImpl.java
@@ -5,6 +5,7 @@ import com.example.backend.exception.RewardException;
 import com.example.backend.userPoint.dto.response.PaymentResponseDTO;
 import com.example.backend.userPoint.repository.UserPointRepository;
 import jakarta.persistence.EntityNotFoundException;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 @Service

--- a/backend/src/main/java/com/example/backend/webSocket/StompHandshakeInterceptor.java
+++ b/backend/src/main/java/com/example/backend/webSocket/StompHandshakeInterceptor.java
@@ -1,5 +1,7 @@
 package com.example.backend.webSocket;
 
+import com.example.backend.exception.PenaltyException;
+import com.example.backend.userPenalty.service.UserPenaltyService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
@@ -16,9 +18,12 @@ public class StompHandshakeInterceptor implements HandshakeInterceptor {
 
     private final OAuthTokenVerifier tokenVerifier;
 
+    private final UserPenaltyService userPenaltyService;
+
     @Autowired
-    public StompHandshakeInterceptor(OAuthTokenVerifier tokenVerifier) {
+    public StompHandshakeInterceptor(OAuthTokenVerifier tokenVerifier, UserPenaltyService userPenaltyService) {
         this.tokenVerifier = tokenVerifier;
+        this.userPenaltyService = userPenaltyService;
     }
 
     @Override
@@ -42,6 +47,13 @@ public class StompHandshakeInterceptor implements HandshakeInterceptor {
 
         String token = tokenHeader.substring("Bearer ".length());
         String userId = tokenVerifier.getUserIdFromAccessToken(token);
+
+        // 유저의 패널티 적용 기간.
+        String penaltyTime =  userPenaltyService.existEndAtUserId(Long.valueOf(userId));
+        if(penaltyTime != null){
+            System.out.println("해당 유저의 패널티 적용기간이 남아있습니다."+penaltyTime);
+            throw new PenaltyException("정지 남은 시간 : " +penaltyTime);
+        }
 
         if (userId == null) {
             System.out.println("❌ 토큰 유효성 실패 형님!!!");

--- a/frontend/src/screens/localBoard/LocalBoardDetail.tsx
+++ b/frontend/src/screens/localBoard/LocalBoardDetail.tsx
@@ -35,6 +35,14 @@ export default function LocalBoardDetail() {
     const activeOptionModal = () =>{
       optionModalRef.current?.present()
     };
+
+    const handleReportPress = () => {
+      optionModalRef.current?.dismiss();
+      navigation.navigate('ReportScreen', {
+        type: 'post',
+        postId: post?.id,
+    });
+};
   
     useLayoutEffect(() => {
       navigation.setOptions({
@@ -50,17 +58,7 @@ export default function LocalBoardDetail() {
       fetchPostDetail(id);
     },[navigation])
 
-  // const postingInfo = [
-  //   {
-  //     id: id,
-  //     authorId: 1001,
-  //     author: '서샘이',
-  //     date: '2025년 4월 24일',
-  //     title: '광주 vs 광주',
-  //     content: '경기도 광주 vs 광주광역시 누가 더 시골이라고 생각하시나요?',
-  //     image: 'https://via.placeholder.com/350x200',
-  //   },
-  // ];
+
   
 
       const [postingInfo, setPost] = useState<{

--- a/frontend/src/screens/localBoard/WriteLocalPost.tsx
+++ b/frontend/src/screens/localBoard/WriteLocalPost.tsx
@@ -11,6 +11,7 @@ import { useFireBaseImage } from '../../hooks/UseFirebaseImage';
 import { useImagePicker } from '../../hooks/useImagePicker';
 //imagePriview UI
 import ImagePreviewList from '../../components/image/ImagePreviewList';
+import { useModal } from '../../context/ModalContext';
 
 export default function WriteLocalBoardPost() {
   const {user, setUser} = useUser();
@@ -18,6 +19,7 @@ export default function WriteLocalBoardPost() {
   const [content, setContent] = useState('');
   const { images, pickImages, deleteImage } = useImagePicker();
   const { uploadImage, deleteImageFB, uploading, error } = useFireBaseImage();
+  const {showModal, hideModal} = useModal();
 
   const handleSubmit =  async () =>{
     let uploadedImageUrls: string[] | null = null;
@@ -38,11 +40,19 @@ export default function WriteLocalBoardPost() {
 
   await api.post('local-board/detail/create', formData);
 
-    } catch (error) {
+    } catch (error :any) {
       console.error('게시글 등록 실패:', error);
         if(uploadedImageUrls != null && uploadedImageUrls.length > 0){
               await deleteImageFB(uploadedImageUrls);
         }
+        const message =
+            error.response?.data?.message ||
+            error.message
+            '알 수 없는 오류가 발생했습니다.';
+            showModal({
+                type:'confirm',
+                content : message,
+            })  
     }
   };
 

--- a/frontend/src/screens/mission/MissionScreen.tsx
+++ b/frontend/src/screens/mission/MissionScreen.tsx
@@ -116,9 +116,8 @@
           source: previewMissionContent,
           userMissionId: userMissionStatusId,
       };
-        const res = api.post(`mission/status/update`,requestBody);
+        const res = api.post(`mission/status/update/${userId}`,requestBody);
         console.log(res);
-
         setDailyMissions((prevMissions) =>
       prevMissions.map((mission) =>
         mission.userMissionStatusId === userMissionStatusId

--- a/frontend/src/screens/report/ReportScreen.tsx
+++ b/frontend/src/screens/report/ReportScreen.tsx
@@ -12,13 +12,92 @@ import {
   widthPercentageToDP as wp,
   heightPercentageToDP as hp,
 } from 'react-native-responsive-screen';
+import { RouteProp, useRoute } from '@react-navigation/native';
+import api from '../../api/AxiosInstance';
+import { useUser } from '../../context/UserContext';
+import { useNavigation } from '@react-navigation/native';
+import { useModal } from '../../context/ModalContext';
 
-const categories = ['욕설/비방', '광고/도배', '허위', '기타'];
+
+
+const categories = ['스팸홍보/도배글입니다.', '음란물 또는 불법 촬영물입니다.', '불법 정보를 포함하고 있습니다.', '청소년에게 유해한 내용입니다.',
+  '욕설/생명경시/혐오/차별적 표현입니다.', '개인정보 노출 게시물입니다.', '불쾌한 표현이 있습니다.', '명예훼손 또는 저작권 침해되었습니다.'
+];
+
+type ReportRouteParams = {
+  type: 'post' | 'comment' | 'chat_message' | 'chat_room' | 'sharing' | 'sharing_log';
+  postId?: number;
+  commentId?: number;
+  chatMessageId?: number;
+  chatRoomId?: number;
+  sharingId?: number;
+  sharingLogId?: number;
+};
 
 export default function ReportForm() {
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [reportContent, setReportContent] = useState('');
   const [isDropdownVisible, setDropdownVisible] = useState(false);
+  const {user, setUser} = useUser();
+  const reasonCode = categories.indexOf(selectedCategory ?? '');
+  const route = useRoute<RouteProp<Record<string, ReportRouteParams>, string>>();
+  const navigation = useNavigation();
+  const {showModal, hideModal} = useModal();
+  
+
+  const idMap: Record<string, number | undefined> = {
+  post: route.params.postId,
+  comment: route.params.commentId,
+  chat_message: route.params.chatMessageId,
+  chat_room: route.params.chatRoomId,
+  sharing: route.params.sharingId,
+  sharing_log: route.params.sharingLogId,
+};
+
+
+  const { type, postId, commentId, chatMessageId, chatRoomId, sharingId, sharingLogId } = route.params;
+  
+  const targetId = type === 'post' ? postId : commentId;
+
+  console.log('신고 타입:', type);
+  console.log('신고 대상 ID:', targetId);
+
+  const submitButton = async() => {
+
+  if (reasonCode === -1) {
+    // 카테고리가 선택되지 않은 경우 처리
+    showModal({
+      type: 'confirm',
+      content: '신고 카테고리를 선택해주세요.',
+    });
+    return; // 함수 종료해서 아래 API 호출 안 함
+  }
+
+    try{
+        const data = {
+          reporterId: user?.userId,
+          targetType: type,  // 백엔드 enum에 맞게 소문자, 언더바로 맞춤
+          targetId: targetId,
+          reasonCode: categories.indexOf(selectedCategory ?? ''),
+        details: reportContent,
+        };
+      const res = await api.post('report/submit', data);
+      showModal({
+                type:'confirm',
+                content : '신고처리가 완료되었습니다.',
+                onConfirm: () => navigation.goBack()
+            })  
+    }catch(error:any){
+      const message =
+            error.response?.data?.message ||
+            error.message
+            '알 수 없는 오류가 발생했습니다.';
+            showModal({
+                type:'confirm',
+                content : message,
+            })  
+    }
+  }
 
   return (
     <View style={styles.container}>
@@ -49,7 +128,7 @@ export default function ReportForm() {
                   setDropdownVisible(false);
                 }}
               >
-                <Text>{item}</Text>
+                <Text style={styles.dropdownItemText}>{item}</Text>
               </TouchableOpacity>
             ))}
           </View>
@@ -64,7 +143,7 @@ export default function ReportForm() {
         onChangeText={setReportContent}
       />
 
-      <TouchableOpacity style={styles.submitButton}>
+      <TouchableOpacity style={styles.submitButton} onPress={submitButton}>
         <Text style={styles.submitText}>신고</Text>
       </TouchableOpacity>
     </View>
@@ -98,7 +177,7 @@ const styles = StyleSheet.create({
     color: '#333',
   },
   dropdownIcon: {
-    fontSize: wp('4%'),
+    fontSize: wp('5%'),
   },
   modalOverlay: {
     flex: 1,
@@ -112,9 +191,14 @@ const styles = StyleSheet.create({
     paddingVertical: hp('1%'),
   },
   dropdownItem: {
-    paddingVertical: hp('1.5%'),
+    paddingVertical: hp('3%'),
     paddingHorizontal: wp('4%'),
   },
+  dropdownItemText: {
+    fontSize: wp('4%'), 
+    color: '#333',
+    fontWeight : 'bold'
+} ,
   textArea: {
     height: hp('25%'),
     borderColor: '#ccc',

--- a/frontend/src/screens/reward/RewardPay.tsx
+++ b/frontend/src/screens/reward/RewardPay.tsx
@@ -16,6 +16,8 @@ import { formatTOKSTDateTime } from "../../utils/TimeStampToConvert";
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { AppStackParamList } from '../../navigation/AppNavigator';
+import { useUser } from '../../context/UserContext';
+
 
 
 type RewardScreenNavigationProp = RouteProp<RewardParamList,'RewardPay'>;
@@ -26,6 +28,8 @@ const RewardPay = () => {
   const { userPointId } = route.params;
   const {showModal, hideModal} = useModal();
   const navigation = useNavigation<Navigation>();
+  const {user, setUser} = useUser();
+  const userId =user?.userId;
   
   interface payResultData{
     id : number,

--- a/frontend/src/screens/sharing/SharingDetail.tsx
+++ b/frontend/src/screens/sharing/SharingDetail.tsx
@@ -80,6 +80,14 @@ export default function SharingDetail() {
     optionModalRef.current?.present();
   };
 
+//   const handleReportPress = () => {
+//       optionModalRef.current?.dismiss();
+//       navigation.navigate('ReportScreen', {
+//         type: 'sharing',
+//         sharingId: sharing?.id,
+//     });
+// };
+
   useLayoutEffect(() => {
     navigation.setOptions({
       headerRight: () => (


### PR DESCRIPTION
## 🔍 관련 이슈
- related to #85 

## 💡 작업 내용
<!-- 주요 변경 사항을 리스트로 작성해주세요 -->
- 사용자가 지역게시판, 댓글을 신고할 수 잇는 기능 구현함(백엔드,프론트)
- 채팅, 나눔 게시판은 아직 구현이 완전히 되지 않은 상황이어서 해당 기능을 다 구현하지 못하였음. 
- 채팅방, 채팅 메세지, 나눔 게시판과 나눔 거래는  어떻게 적용할지도 고민하는 중. 
- 관리자가 신고 기록을 보고 사용자가에게 패널티에게 가할 수 있는 기능 백엔드 구현. 
- 위의 기능의 프론트는 아직 관리자 전용 웹을 구성하는 동시에 진행하겠음. 

- 신고, 미션, 리워드 상품의 등록, 수정, 삭제 시 권한 체크(Rest API 요청 시 @PreAuthorize 어노테이션을 이용하여 일종의 미들웨어 가드  역할 부여)


## 🧪 테스트
- Junit Test,Post Men , Android Studio 

## 📎 참고자료 (선택)
