### PR TITLE
[refactor] 리워드(포인트) 상품 결제 또는 환불시 동시성 문제 리펙토링

### DIFF
--- a/backend/src/main/java/com/example/backend/reward/rewardItems/repository/RewardRepository.java
+++ b/backend/src/main/java/com/example/backend/reward/rewardItems/repository/RewardRepository.java
@@ -1,13 +1,21 @@
 package com.example.backend.reward.rewardItems.repository;
 
 import com.example.backend.entity.reward.RewardItems;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface RewardRepository extends JpaRepository<RewardItems,Long>, RewardRepositoryCustom {
     long countByRewardTypeAndStockGreaterThan(RewardItems.RewardType rewardType, int stock);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM RewardItems r " +
+            " WHERE r.id = :id")
+    public Optional<RewardItems> findByRewardItemInfo(@Param("id") Long id);
 }

--- a/backend/src/main/java/com/example/backend/reward/userReward/repository/UserRewardRepository.java
+++ b/backend/src/main/java/com/example/backend/reward/userReward/repository/UserRewardRepository.java
@@ -1,7 +1,9 @@
 package com.example.backend.reward.userReward.repository;
 
 import com.example.backend.entity.reward.UserRewards;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -11,6 +13,7 @@ import java.util.Optional;
 
 @Repository
 public interface UserRewardRepository extends JpaRepository<UserRewards,Long>, UserRewardRepositoryCustom {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT r FROM UserRewards r WHERE r.userPointId = :userPointId")
     Optional<UserRewards> findByPointId(@Param("userPointId") Long userPointId);
 

--- a/backend/src/main/java/com/example/backend/reward/userReward/service/UserRewardServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/reward/userReward/service/UserRewardServiceImpl.java
@@ -80,7 +80,7 @@ public class UserRewardServiceImpl implements UserRewardService {
 
     @Override
     public Long userFindPoint(Long userId) {
-        Long currentPoint = userRepository.findCurrentPointByUserId(userId);
+        Long currentPoint = userRepository.findCurrentPointUserId(userId);
         if(currentPoint == null){
             currentPoint = 0l;
         }

--- a/backend/src/main/java/com/example/backend/reward/userReward/service/UserRewardServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/reward/userReward/service/UserRewardServiceImpl.java
@@ -3,18 +3,15 @@ package com.example.backend.reward.userReward.service;
 import com.example.backend.entity.reward.RewardItems;
 import com.example.backend.entity.reward.UserRewards;
 import com.example.backend.entity.user.UserPoint;
-import com.example.backend.exception.InsufficientPointException;
-
 import com.example.backend.exception.RewardException;
 import com.example.backend.reward.rewardItems.repository.RewardRepository;
 import com.example.backend.reward.userReward.dto.request.UserRewardPointRequestInsertDTO;
 import com.example.backend.reward.userReward.repository.UserRewardRepository;
 import com.example.backend.user.repository.UserRepository;
 import com.example.backend.userPoint.repository.UserPointRepository;
-import jakarta.persistence.EntityNotFoundException;
-import jakarta.transaction.Transactional;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class UserRewardServiceImpl implements UserRewardService {
@@ -39,27 +36,30 @@ public class UserRewardServiceImpl implements UserRewardService {
     // 4. 유저 리워드 등록
     // 5. 재고 예외처리
     // 6. 유저 현재 포인트 업데이트
-    @Transactional
+    @Transactional(timeout = 5)
     @Override
     @PreAuthorize("isAuthenticated()")
     public Long userRewardPointInsert(UserRewardPointRequestInsertDTO dto) {
         long amount = dto.getAmount();
         long id = dto.getUserId();
 
-
+        // 1. 특정 유저의 현재 포인트 조회 쿼리(Lock 적용)
         long currentPoint = userRepository.findCurrentPointByUserId(id);
+
         if (currentPoint == 0) {
             throw new RewardException("보유하신 포인트가 없습니다.");
         } else if (currentPoint < amount) {
             throw new RewardException("보유하신 포인트가 적습니다. 보유 : " + currentPoint + "p , 차감 : " + amount + "p");
         }
-
+        // 2. 유저 포인트 테이블 등록 (로그)
         UserPoint point = userPointRepository.save(dto.toEntityUserPoint());
         long userPointId = point.getId();
+
+        // 3. 유저 리워드 테이블 등록(로그,  결제 정보)
         userRewardRepository.save(dto.toEntityUserReward(userPointId));
 
-
-        RewardItems rewardItems = rewardRepository.findById(dto.getRewardItemId())
+        // 4. 리워드 상품의 재고 조회 쿼리(Lock 적용)
+        RewardItems rewardItems = rewardRepository.findByRewardItemInfo(dto.getRewardItemId())
                 .orElseThrow(() -> new RewardException("해당 상품이 존재 하지 않습니다."));
 
         if (rewardItems.getRewardType() != RewardItems.RewardType.DONATION) {
@@ -94,10 +94,11 @@ public class UserRewardServiceImpl implements UserRewardService {
     // 재고 업데이트
     // 유저의 현재 포인트와 총 포인트 업데이트
     @Override
-    @Transactional
+    @Transactional(timeout = 5)
     @PreAuthorize("hasRole('ADMIN') or (isAuthenticated() and @userRewardService.isOwnerOfUserPoint(#userPointId, principal.id))")
     public void userRewardPayRefund(Long userPointId) {
-        UserPoint point =  userPointRepository.findById(userPointId)
+        // LOCK 적용.
+        UserPoint point =  userPointRepository.findByUserPoint(userPointId)
         .orElseThrow(() -> new RewardException("결제 정보가 존재하지 않습니다."));
 
         if(point.getPointType().equals("환불")){
@@ -114,6 +115,8 @@ public class UserRewardServiceImpl implements UserRewardService {
                 .build();
         userPointRepository.save(refundPoint);
 
+
+        // Lock 적용.
         UserRewards userRewards =  userRewardRepository.findByPointId(userPointId)
                 .orElseThrow(() -> new RewardException("결제 정보가 존재하지 않습니다."));
 
@@ -129,7 +132,8 @@ public class UserRewardServiceImpl implements UserRewardService {
                 .build();
         userRewardRepository.save(refundReward);
 
-        RewardItems rewardItem = rewardRepository.findById(refundReward.getRewardItemId())
+        // Lock 적용.
+        RewardItems rewardItem = rewardRepository.findByRewardItemInfo(refundReward.getRewardItemId())
                 .orElseThrow(() -> new RewardException("해당 상품이 존재 하지 않습니다."));
 
         if (rewardItem.getRewardType() != RewardItems.RewardType.DONATION) {
@@ -137,6 +141,7 @@ public class UserRewardServiceImpl implements UserRewardService {
             rewardRepository.save(rewardItem);
         }
 
+        // Lock 적용.
         long currentPoint = userRepository.findCurrentPointByUserId(point.getUserId());
         long resultPoint =  currentPoint + point.getAmount();
         userRepository.updateCurrentPoint(resultPoint, point.getUserId());

--- a/backend/src/main/java/com/example/backend/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/example/backend/user/repository/UserRepository.java
@@ -23,10 +23,14 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
     boolean existsByEmail(String email);
     boolean existsByNickname(String nickname);
 
-    // 유저의 현재 포인트
+    // 유저의 현재 포인트 Lock
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT u.currentPoint FROM User u WHERE u.id= :userId")
     long findCurrentPointByUserId(@Param("userId") long userId);
+
+    // 유저의 현재 포인트
+    @Query("SELECT u.currentPoint FROM User u WHERE u.id= :userId")
+    long findCurrentPointUserId(@Param("userId") long userId);
 
 
     //유저의 현재 , 총 포인트, 유저 등급

--- a/backend/src/main/java/com/example/backend/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/example/backend/user/repository/UserRepository.java
@@ -4,9 +4,11 @@ import com.example.backend.entity.user.User;
 import com.example.backend.user.dto.UserCurrentAndTotalPointResponseDTO;
 import com.example.backend.user.vo.Email;
 import com.example.backend.user.vo.Nickname;
+import jakarta.persistence.LockModeType;
 import jakarta.transaction.Transactional;
 import com.example.backend.entity.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -22,6 +24,7 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
     boolean existsByNickname(String nickname);
 
     // 유저의 현재 포인트
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT u.currentPoint FROM User u WHERE u.id= :userId")
     long findCurrentPointByUserId(@Param("userId") long userId);
 

--- a/backend/src/main/java/com/example/backend/userPoint/repository/UserPointRepository.java
+++ b/backend/src/main/java/com/example/backend/userPoint/repository/UserPointRepository.java
@@ -2,12 +2,19 @@ package com.example.backend.userPoint.repository;
 
 import com.example.backend.entity.user.UserPoint;
 import com.example.backend.userPoint.dto.response.PaymentResponseDTO;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserPointRepository extends JpaRepository<UserPoint , Long>, UserPointRepositoryCustom {
-
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT up FROM UserPoint up " +
+            " WHERE id = :id")
+    public Optional<UserPoint> findByUserPoint(long id);
 }


### PR DESCRIPTION
## 🔍 관련 이슈
- close #43 

## 💡 작업 내용
<!-- 주요 변경 사항을 리스트로 작성해주세요 -->
- 비관적 락(Pessimistic Lock)을 걸어서 결제 시, 유저의 현재 포인트, 상품의 재고의 동시성 문제 리펙토링.
- 비관적 락(Pessimistic Lock)을 걸어서 환불 시, 유저의 현재포인트, 유저 포인트 로그 테이블, 리워드 상품 로그 테이블, 리워드 상품 재고의 동서성 문제 리펙토링. 
- userRewardServiceImpl, UserPointRepository, UserRepository, RewardRespotiroy, UserRewardRepository 로직 업데이트


## 🧪 테스트
- Android Studio, Junti Test

## 📎 참고자료 (선택)